### PR TITLE
feature/link with backend

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "era-connect"]
+	path = era-connect
+	url = https://github.com/RPMTW/era-connect.git
+	branch = feature/collection-frb-v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,16 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[workspace]
+
+members = [
+  "era-connect/app/rust",
+]
+
+default-members = [
+  "era-connect/app/rust",
+]
+
 [dependencies]
 
 rust_lib = { path = "./era-connect/app/rust/" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,16 +6,6 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[workspace]
-
-members = [
-  "era-connect/app/rust",
-]
-
-default-members = [
-  "era-connect/app/rust",
-]
-
 [dependencies]
 
 rust_lib = { path = "./era-connect/app/rust/" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2021"
 
 [dependencies]
 
+rust_lib = { path = "./era-connect/app/rust/" }
+
 dioxus = { version = "0.5.1", features = ["desktop", "router"] }
 
 # Debug

--- a/public/tailwind.css
+++ b/public/tailwind.css
@@ -1497,12 +1497,20 @@ html {
   left: 0px;
 }
 
+.start-0 {
+  inset-inline-start: 0px;
+}
+
 .top-0 {
   top: 0px;
 }
 
 .z-0 {
   z-index: 0;
+}
+
+.z-10 {
+  z-index: 10;
 }
 
 .z-20 {
@@ -1906,6 +1914,10 @@ html {
   overflow: scroll;
 }
 
+.overflow-y-scroll {
+  overflow-y: scroll;
+}
+
 .scroll-smooth {
   scroll-behavior: smooth;
 }
@@ -1968,11 +1980,6 @@ html {
 .border-zinc-900 {
   --tw-border-opacity: 1;
   border-color: rgb(24 24 27 / var(--tw-border-opacity));
-}
-
-.border-deep-background {
-  --tw-border-opacity: 1;
-  border-color: rgb(14 14 14 / var(--tw-border-opacity));
 }
 
 .bg-\[\#CCE246\] {
@@ -2377,12 +2384,20 @@ body {
   height: 5rem;
 }
 
+.group[aria-expanded="true"] .group-aria-expanded\:h-full {
+  height: 100%;
+}
+
 .group[aria-expanded="true"] .group-aria-expanded\:min-h-20 {
   min-height: 5rem;
 }
 
 .group[aria-expanded="true"] .group-aria-expanded\:w-20 {
   width: 5rem;
+}
+
+.group[aria-expanded="true"] .group-aria-expanded\:w-full {
+  width: 100%;
 }
 
 .group[aria-expanded="true"] .group-aria-expanded\:rounded-\[5px\] {

--- a/src/Collections.rs
+++ b/src/Collections.rs
@@ -1,4 +1,5 @@
 use dioxus::prelude::*;
+use rust_lib::api::shared_resources::{authentication::MINECRAFT_USER_PROFILE_URL, entry::STORAGE};
 
 use crate::{
     BaseComponents::{Alignment, Button, ContentType, Contents, FillMode, Roundness, Size},
@@ -8,6 +9,11 @@ use crate::{
 
 #[component]
 pub fn Collections() -> Element {
+    let collections =
+        use_resource(
+            move || async move { STORAGE.collections.clone().read_owned().await.to_owned() },
+        );
+    let collections_iterator = collections().into_iter().flat_map(|x| x.into_iter());
     rsx! {
         div { class: "flex flex-col space-y-[10px]",
             div { class: "flex space-x-[10px]",
@@ -49,41 +55,12 @@ pub fn Collections() -> Element {
                 }
             }
             div { class: "grid grid-flow-row grid-cols-[repeat(auto-fill,280px)] gap-[20px]",
-                CollectionBlock {
-                    extended_class: "rounded-[20px]",
-                    main_text: "創世幻想",
-                    hint: "不久前開啟•由我建立",
-                    picture: COLLECTION_PIC
-                }
-                CollectionBlock {
-                    extended_class: "rounded-[20px]",
-                    main_text: "text",
-                    hint: "arst",
-                    picture: COLLECTION_PIC
-                }
-                CollectionBlock {
-                    extended_class: "rounded-[20px]",
-                    main_text: "text",
-                    hint: "arst",
-                    picture: COLLECTION_PIC
-                }
-                CollectionBlock {
-                    extended_class: "rounded-[20px]",
-                    main_text: "text",
-                    hint: "arst",
-                    picture: COLLECTION_PIC
-                }
-                CollectionBlock {
-                    extended_class: "rounded-[20px]",
-                    main_text: "text",
-                    hint: "arst",
-                    picture: COLLECTION_PIC
-                }
-                CollectionBlock {
-                    extended_class: "rounded-[20px]",
-                    main_text: "text",
-                    hint: "arst",
-                    picture: COLLECTION_PIC
+                for collection in collections_iterator {
+                    CollectionBlock {
+                        collection: Some(collection),
+                        extended_class: "rounded-[20px]",
+                        picture: COLLECTION_PIC
+                    }
                 }
             }
         }

--- a/src/Collections.rs
+++ b/src/Collections.rs
@@ -57,7 +57,7 @@ pub fn Collections() -> Element {
             div { class: "grid grid-flow-row grid-cols-[repeat(auto-fill,280px)] gap-[20px]",
                 for collection in collections_iterator {
                     CollectionBlock {
-                        collection: Some(collection),
+                        collection,
                         extended_class: "rounded-[20px]",
                         picture: COLLECTION_PIC
                     }

--- a/src/MainPage.rs
+++ b/src/MainPage.rs
@@ -1,7 +1,7 @@
 use dioxus::prelude::*;
 
 use manganis::ImageAsset;
-use rust_lib::api::shared_resources::{collection::Collection, entry::STORAGE};
+use rust_lib::api::shared_resources::collection::Collection;
 use tailwind_fuse::*;
 
 use crate::{
@@ -12,11 +12,13 @@ use crate::{
 };
 
 pub const COLLECTION_PIC: ImageAsset =
-    manganis::mg!(image("./public/pic1.png").format(ImageType::Avif));
+    manganis::mg!(image("./public/pic1.png").format(ImageType::Avif).preload());
 pub const BLOCK: &str = manganis::mg!(file("./public/block.svg"));
 pub const EXPAND_CONTENT: &str = manganis::mg!(file("./public/expand_content.svg"));
 pub const ICON: &str = manganis::mg!(file("./public/icon.svg"));
-pub const IMG: ImageAsset = manganis::mg!(image("./public/project.png"));
+pub const IMG: ImageAsset = manganis::mg!(image("./public/project.png")
+    .format(ImageType::Avif)
+    .preload());
 pub const STAR: &str = manganis::mg!(file("./public/award_star.svg"));
 pub const ARROW_LEFT: &str = manganis::mg!(file("./public/keyboard_arrow_left.svg"));
 pub const ARROW_RIGHT: &str = manganis::mg!(file("./public/keyboard_arrow_right.svg"));

--- a/src/MainPage.rs
+++ b/src/MainPage.rs
@@ -7,8 +7,9 @@ use tailwind_fuse::*;
 use crate::{
     get_collections,
     BaseComponents::{
-        Alignment, Button, ButtonClass, ContentType, Contents, FillMode, Roundness, Size,
+        Alignment, Button, ButtonClass, ContentType, Contents, FillMode, Roundness, Size, Switcher,
     },
+    Pages, ACTIVE_PAGE,
 };
 
 pub const COLLECTION_PIC: ImageAsset =
@@ -34,13 +35,13 @@ pub fn MainPage() -> Element {
 /// Creates a Collection Block with a `280px` square, with a default roundness of `5px`
 #[component]
 pub fn CollectionBlock(
-    #[props(into)] collection: Option<Collection>,
+    #[props(into)] collection: Collection,
     picture: ImageAsset,
     #[props(default = true)] gradient: bool,
     #[props(extends=GlobalAttributes)] attributes: Vec<Attribute>,
     #[props(default)] extended_class: String,
 ) -> Element {
-    let main_text = collection.map(|x| x.display_name);
+    let main_text = collection.display_name.clone();
     let hint = String::from("遊玩中•由我建立");
     let (roundness, extended_class): (Vec<_>, Vec<_>) = extended_class
         .split_whitespace()
@@ -52,8 +53,11 @@ pub fn CollectionBlock(
     }
     rsx! {
         div {
-            div {
+            button {
                 class: tw_merge!("relative h-[280px] w-[280px]", extended_class),
+                onclick: move |_| {
+                    Pages::new_collection_page(collection.get_collection_id()).switch_active_to_self();
+                },
                 ..attributes,
                 img { class: img_class, src: picture }
                 if gradient {

--- a/src/MainPage.rs
+++ b/src/MainPage.rs
@@ -4,8 +4,11 @@ use manganis::ImageAsset;
 use rust_lib::api::shared_resources::{collection::Collection, entry::STORAGE};
 use tailwind_fuse::*;
 
-use crate::BaseComponents::{
-    Alignment, Button, ButtonClass, ContentType, Contents, FillMode, Roundness, Size,
+use crate::{
+    get_collections,
+    BaseComponents::{
+        Alignment, Button, ButtonClass, ContentType, Contents, FillMode, Roundness, Size,
+    },
 };
 
 pub const COLLECTION_PIC: ImageAsset =
@@ -242,11 +245,8 @@ fn SuggestionPage() -> Element {
 
 #[component]
 fn CollectionsPage() -> Element {
-    let collections =
-        use_resource(
-            move || async move { STORAGE.collections.clone().read_owned().await.to_owned() },
-        );
-    let collections_iterator = collections().into_iter().flat_map(|x| x.into_iter());
+    let collections = get_collections();
+    let collections_iterator = collections().into_iter().flatten();
 
     rsx! {
         div { class: "flex flex-col space-x-0",

--- a/src/MainPage.rs
+++ b/src/MainPage.rs
@@ -1,6 +1,7 @@
 use dioxus::prelude::*;
 
 use manganis::ImageAsset;
+use rust_lib::api::shared_resources::{collection::Collection, entry::STORAGE};
 use tailwind_fuse::*;
 
 use crate::BaseComponents::{
@@ -28,13 +29,14 @@ pub fn MainPage() -> Element {
 /// Creates a Collection Block with a `280px` square, with a default roundness of `5px`
 #[component]
 pub fn CollectionBlock(
-    #[props(into)] main_text: Option<String>,
-    #[props(into)] hint: Option<String>,
+    #[props(into)] collection: Option<Collection>,
     picture: ImageAsset,
     #[props(default = true)] gradient: bool,
     #[props(extends=GlobalAttributes)] attributes: Vec<Attribute>,
     #[props(default)] extended_class: String,
 ) -> Element {
+    let main_text = collection.map(|x| x.display_name);
+    let hint = String::from("遊玩中•由我建立");
     let (roundness, extended_class): (Vec<_>, Vec<_>) = extended_class
         .split(' ')
         .partition(|x| x.contains("rounded"));
@@ -240,6 +242,12 @@ fn SuggestionPage() -> Element {
 
 #[component]
 fn CollectionsPage() -> Element {
+    let collections =
+        use_resource(
+            move || async move { STORAGE.collections.clone().read_owned().await.to_owned() },
+        );
+    let collections_iterator = collections().into_iter().flat_map(|x| x.into_iter());
+
     rsx! {
         div { class: "flex flex-col space-x-0",
             Button {
@@ -268,45 +276,11 @@ fn CollectionsPage() -> Element {
             }
             div { class: ButtonClass::builder().roundness(Roundness::Bottom).with_class("min-w-screen p-0"),
                 div { class: "flex space-x-[3px] overflow-scroll",
-                    CollectionBlock {
-                        main_text: "創世幻想",
-                        hint: "不久前開啟•由我建立",
-                        picture: COLLECTION_PIC
-                    }
-                    CollectionBlock {
-                        main_text: "創世幻想arstarstat",
-                        hint: "不久前開啟•由我建立",
-                        picture: COLLECTION_PIC
-                    }
-                    CollectionBlock {
-                        main_text: "創世幻想",
-                        hint: "不久前開啟•由我建立",
-                        picture: COLLECTION_PIC
-                    }
-                    CollectionBlock {
-                        main_text: "創世幻想",
-                        hint: "不久前開啟•由我建立",
-                        picture: COLLECTION_PIC
-                    }
-                    CollectionBlock {
-                        main_text: "創世幻想",
-                        hint: "不久前開啟•由我建立",
-                        picture: COLLECTION_PIC
-                    }
-                    CollectionBlock {
-                        main_text: "創世幻想",
-                        hint: "不久前開啟•由我建立",
-                        picture: COLLECTION_PIC
-                    }
-                    CollectionBlock {
-                        main_text: "創世幻想",
-                        hint: "不久前開啟•由我建立",
-                        picture: COLLECTION_PIC
-                    }
-                    CollectionBlock {
-                        main_text: "創世幻想",
-                        hint: "不久前開啟•由我建立",
-                        picture: COLLECTION_PIC
+                    for collection in collections_iterator {
+                        CollectionBlock {
+                            collection,
+                            picture: COLLECTION_PIC
+                        }
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ pub mod BaseComponents;
 pub mod Collections;
 pub mod MainPage;
 
-use anyhow::bail;
 use dioxus::desktop::tao::dpi::PhysicalSize;
 use dioxus::desktop::WindowBuilder;
 use std::hash::{DefaultHasher, Hash, Hasher};
@@ -33,6 +32,8 @@ static ACTIVE_PAGE: GlobalSignal<(Pages, Option<Pages>)> =
     GlobalSignal::new(|| (Pages::MainPage, None));
 pub static TOP_LEVEL_COMPONENT: GlobalSignal<Vec<ComponentPointer<subModalProps>>> =
     GlobalSignal::new(Vec::new);
+
+use rust_lib::api::shared_resources::entry;
 
 fn main() {
     dioxus_logger::init(LevelFilter::Info).expect("failed to init logger");
@@ -188,6 +189,15 @@ impl ToString for Pages {
 #[component]
 fn App() -> Element {
     let error_active = use_signal(|| true);
+    spawn(async move {
+        let versions = rust_lib::api::backend_exclusive::vanilla::version::get_versions()
+            .await
+            .unwrap();
+        let version = versions.into_iter().find(|x| x.id == "1.20.1").unwrap();
+        entry::create_collection("test", version, None, None)
+            .await
+            .unwrap();
+    });
     rsx! {
         div { class: "bg-deep-background min-h-screen min-w-full font-display leading-normal",
             {

--- a/src/main.rs
+++ b/src/main.rs
@@ -611,9 +611,13 @@ fn SidebarCollectionBlock(
             ],
             signal: Rc::new(Pages::new_collection_page(signal_check())) as Rc<dyn ActiveCompare>,
             focus_color_change: false,
-            background_image: format!("linear-gradient(to right, rgba(25, 25, 25, 0.8) 0%, rgba(25, 25, 25, 1) 68%, rgba(25, 25, 25, 1) 100%),url(\"{}\")",COLLECTION_PIC),
+            background_image: darken_sidebar_background(COLLECTION_PIC),
             background_size: "cover",
             extended_css_class: "bg-background object-cover transition-all delay-[25ms] group-aria-expanded:w-20 group-aria-expanded:min-h-20 group-aria-expanded:p-0"
         }
     }
+}
+
+fn darken_sidebar_background(s: impl ToString) -> String {
+    format!("linear-gradient(to right, rgba(25, 25, 25, 0.8) 0%, rgba(25, 25, 25, 1) 68%, rgba(25, 25, 25, 1) 100%),url(\"{}\")", s.to_string())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ pub mod MainPage;
 
 use dioxus::desktop::tao::dpi::PhysicalSize;
 use dioxus::desktop::WindowBuilder;
+use rust_lib::api::shared_resources::collection::Collection;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::rc::Rc;
 use std::sync::Arc;
@@ -33,7 +34,7 @@ static ACTIVE_PAGE: GlobalSignal<(Pages, Option<Pages>)> =
 pub static TOP_LEVEL_COMPONENT: GlobalSignal<Vec<ComponentPointer<subModalProps>>> =
     GlobalSignal::new(Vec::new);
 
-use rust_lib::api::shared_resources::entry;
+use rust_lib::api::shared_resources::entry::{self, STORAGE};
 
 fn main() {
     dioxus_logger::init(LevelFilter::Info).expect("failed to init logger");
@@ -186,18 +187,22 @@ impl ToString for Pages {
     }
 }
 
+fn get_collections() -> Resource<Vec<Collection>> {
+    use_resource(move || async move { STORAGE.collections.clone().read_owned().await.to_owned() })
+}
+
 #[component]
 fn App() -> Element {
     let error_active = use_signal(|| true);
-    spawn(async move {
-        let versions = rust_lib::api::backend_exclusive::vanilla::version::get_versions()
-            .await
-            .unwrap();
-        let version = versions.into_iter().find(|x| x.id == "1.20.1").unwrap();
-        entry::create_collection("test", version, None, None)
-            .await
-            .unwrap();
-    });
+    // spawn(async move {
+    //     let versions = rust_lib::api::backend_exclusive::vanilla::version::get_versions()
+    //         .await
+    //         .unwrap();
+    //     let version = versions.into_iter().find(|x| x.id == "1.20.1").unwrap();
+    //     entry::create_collection("fuck test", version, None, None)
+    //         .await
+    //         .unwrap();
+    // });
     rsx! {
         div { class: "bg-deep-background min-h-screen min-w-full font-display leading-normal",
             {
@@ -239,9 +244,18 @@ fn App() -> Element {
 fn Layout() -> Element {
     let selected = ACTIVE_PAGE().0;
     let prev = ACTIVE_PAGE().1;
-    Pages::new_collection_page("新的收藏")
-        .apply_slide_in()
-        .throw()?;
+
+    let collections = get_collections();
+    let collections_iterator = collections().into_iter().flat_map(|x| x.into_iter());
+    for collection in collections_iterator {
+        Pages::new_collection_page(collection.get_collection_id().0)
+            .apply_slide_in()
+            .unwrap();
+    }
+    let collections_iterator = collections()
+        .into_iter()
+        .flatten()
+        .map(|x| (x.get_collection_id().0, x));
     Pages::DownloadProgress.apply_slide_in().throw()?;
     rsx! {
         div {
@@ -264,10 +278,12 @@ fn Layout() -> Element {
                     id: Pages::DownloadProgress.slide_in_id(),
                     LayoutContainer { DownloadProgress {} }
                 }
-                div {
-                    class: "absolute inset-0 z-0 min-h-full min-w-full",
-                    id: Pages::new_collection_page("新的收藏").slide_in_id(),
-                    LayoutContainer { extended_class: "p-0", CollectionPage {} }
+                for (name, collection) in collections_iterator {
+                    div {
+                        class: "absolute inset-0 z-0 min-h-full min-w-full",
+                        id: Pages::new_collection_page(name).slide_in_id(),
+                        LayoutContainer { extended_class: "p-0", CollectionPage {collection} }
+                    }
                 }
             }
         }
@@ -321,14 +337,14 @@ impl ActiveCompare for CollectionPageTopSelection {
 }
 
 #[component]
-fn CollectionPage() -> Element {
+fn CollectionPage(collection: ReadOnlySignal<Collection>) -> Element {
     rsx! {
         div { class: "flex flex-col",
             div { class: "sticky top-0 p-[50px] rounded-2xl bg-slate-800 grid grid-flow-col items-stretch",
                 div { class: "flex flex-col space-y-[35px]",
                     div { class: "text-white font-black text-[80px] leading-normal capsize",
-                        "新的收藏"
-                    }
+                        {collection().display_name}
+                    },
                     Button {
                         roundness: Roundness::Pill,
                         string_placements: vec![ContentType::text("F").css("w-[30px] h-[30px]").align_center()],
@@ -467,6 +483,7 @@ fn SideBar() -> Element {
         Pages::Collections.switch_active_to_self();
         *EXPANDED.write() = !EXPANDED();
     };
+    let collections = get_collections()().into_iter().flatten();
     let folded_images = rsx! {
         div { class: "transition-all",
             {ContentType::svg(HOME).css("hidden group-aria-expanded:block").get_element()},
@@ -534,8 +551,10 @@ fn SideBar() -> Element {
                 // middle
                 div { class: "flex flex-col space-y-1",
                     Button { roundness: Roundness::Top, string_placements: folded_images, extended_css_class: "bg-background" }
-                    SidebarCollectionBlock {
-                        string: "新的收藏"
+                    for collection in collections {
+                        SidebarCollectionBlock {
+                            string: &collection.display_name,
+                        }
                     }
                 }
                 // bottom

--- a/src/main.rs
+++ b/src/main.rs
@@ -554,7 +554,8 @@ fn SideBar() -> Element {
                     Button { roundness: Roundness::Top, string_placements: folded_images, extended_css_class: "bg-background" }
                     for collection in collections {
                         SidebarCollectionBlock {
-                            string: &collection.display_name,
+                            display: &collection.display_name,
+                            signal_check: &collection.get_collection_id().0,
                         }
                     }
                 }
@@ -593,7 +594,10 @@ fn SideBar() -> Element {
 }
 
 #[component]
-fn SidebarCollectionBlock(string: ReadOnlySignal<String>) -> Element {
+fn SidebarCollectionBlock(
+    display: ReadOnlySignal<String>,
+    signal_check: ReadOnlySignal<String>,
+) -> Element {
     rsx! {
         Button {
             roundness: Roundness::None,
@@ -603,9 +607,9 @@ fn SidebarCollectionBlock(string: ReadOnlySignal<String>) -> Element {
                         "transition-all w-[50px] h-[50px] object-cover inline-flex items-center rounded-[15px] border-2 border-zinc-900 group-aria-expanded:w-20 group-aria-expanded:h-20",
                     )
                     .align_left(),
-                ContentType::text(string()).align_right().css("group-aria-busy:hidden"),
+                ContentType::text(display()).align_right().css("group-aria-busy:hidden"),
             ],
-            signal: Rc::new(Pages::new_collection_page(string())) as Rc<dyn ActiveCompare>,
+            signal: Rc::new(Pages::new_collection_page(signal_check())) as Rc<dyn ActiveCompare>,
             focus_color_change: false,
             extended_css_class: "bg-background transition-all delay-[25ms] group-aria-expanded:w-20 group-aria-expanded:min-h-20 group-aria-expanded:p-0"
         }


### PR DESCRIPTION
- **feat: initial links with backend**
- **feat: support for `Collection` propogating between components**
- **chore: use cargo workspace**
- **fix: fix sidebar not selecting collection**
- **Revert "chore: use cargo workspace"**
- **chore: remove explicit option when calling in CollectionBlock**
- **chore: move darken background image builder into a separate function(`darken_sidebar_background`)**
- **feat: added clicking for `CollectionBlock`**
